### PR TITLE
address otdrparser latin-1 handling issue

### DIFF
--- a/otdrparser.py
+++ b/otdrparser.py
@@ -90,15 +90,15 @@ def read_zero_terminated_string(fp):
         fp (file): File object of the opened SOR file.
 
     Returns:
-        unicode: Read unicode string, stripped off leading and trailing white space.
+        string: Read string, stripped off leading and trailing white space.
     """
 
-    s = b""
+    s = bytes()
     while True:
         c = fp.read(1)
         if c == b"\x00":
-            return s.decode().strip()
-        s += c
+            return s.strip()
+        s += bytes(c)
 
 
 def read_fixed_length_string(fp, n):


### PR DESCRIPTION
this will address https://github.com/mjuenema/otdrparser/issues/4

While it's ideal to have all strings be utf-8, I suspect that the telecordia spec does not have unicode support.  There may be other string related bugs, but this preserves parsing with existing files that work on pyOTDR but not otdrparser